### PR TITLE
Use file name as generated mesh name

### DIFF
--- a/Packages/jp.keijiro.metamesh/Editor/MetameshImporter.cs
+++ b/Packages/jp.keijiro.metamesh/Editor/MetameshImporter.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEditor;
 using UnityEngine.Rendering;
+using System.IO;
 #if UNITY_2020_2_OR_NEWER
 using UnityEditor.AssetImporters;
 #else
@@ -53,7 +54,8 @@ public sealed class MetameshImporter : ScriptedImporter
     Mesh ImportAsMesh(string path)
     {
         var mesh = new Mesh();
-        mesh.name = "Mesh";
+        string name = Path.GetFileNameWithoutExtension(path);
+        mesh.name = name;
 
         switch (_shape)
         {


### PR DESCRIPTION
Using the file name to name the mesh makes it easier to find the mesh in public mesh fields.
For example when trying to assign a VFX particle mesh it is hard to find the correct one if they are all called "Mesh"